### PR TITLE
Upgrade Alpine to 3.19 and fix Vulnerabilities

### DIFF
--- a/dockerfiles/4.8.13/php8.2/alpine/Dockerfile
+++ b/dockerfiles/4.8.13/php8.2/alpine/Dockerfile
@@ -1,17 +1,17 @@
-FROM php:8.2.3-cli-alpine3.16
+FROM php:8.2.24-cli-alpine3.19
 
 RUN \
     set -ex && \
     curl -sfL https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
-    chmod +x /usr/bin/composer                                                                     && \
-    composer self-update --clean-backups 2.2.21                                    && \
+    chmod +x /usr/bin/composer && \
+    composer self-update --clean-backups 2.8.1 && \
     apk update && \
     apk add --no-cache libstdc++ && \
     apk add --no-cache --virtual .build-deps $PHPIZE_DEPS curl-dev linux-headers openssl-dev pcre-dev pcre2-dev zlib-dev && \
 # PHP extension pdo_mysql is included since 4.8.12+ and 5.0.1+.
     docker-php-ext-install pdo_mysql && \
     pecl channel-update pecl.php.net && \
-    pecl install --configureoptions 'enable-redis-igbinary="no" enable-redis-lzf="no" enable-redis-zstd="no"' redis-5.3.7 && \
+    pecl install --configureoptions 'enable-redis-igbinary="no" enable-redis-lzf="no" enable-redis-zstd="no"' redis-6.1.0 && \
 # PHP extension Redis is included since 4.8.12+ and 5.0.1+.
     docker-php-ext-enable redis && \
     docker-php-ext-install sockets && \


### PR DESCRIPTION
This pull request includes updates to the Dockerfile for the PHP 8.2 Alpine image to ensure compatibility with newer versions of PHP and dependencies.

### Updates to Dockerfile:

* [`dockerfiles/4.8.13/php8.2/alpine/Dockerfile`](diffhunk://#diff-e109e07ac428b669f306d9824e0a35d8494f1c80efe16c6992272433814c62b2L1-R14): Updated the base image from `php:8.2.3-cli-alpine3.16` to `php:8.2.24-cli-alpine3.19` to use the latest PHP and Alpine versions.
* [`dockerfiles/4.8.13/php8.2/alpine/Dockerfile`](diffhunk://#diff-e109e07ac428b669f306d9824e0a35d8494f1c80efe16c6992272433814c62b2L1-R14): Updated Composer to version 2.8.1 for improved stability and features.
* [`dockerfiles/4.8.13/php8.2/alpine/Dockerfile`](diffhunk://#diff-e109e07ac428b669f306d9824e0a35d8494f1c80efe16c6992272433814c62b2L1-R14): Updated the Redis extension from version 5.3.7 to 6.1.0 to include the latest enhancements and bug fixes.This pull request upgrades the Alpine version from 3.16 to 3.19. The PHP version is also updated to 8.2.24. Additionally, Composer is updated to version 2.8.1. The Redis extension is upgraded to version 6.1.0.

Vulnerabilities found in the Alpine base image (`php:8.2.3-cli-alpine3.16`) used in the `phpswoole/swoole:4.8-php8.2-alpine` image
<img width="880" alt="image" src="https://github.com/user-attachments/assets/b73f7fff-d433-42a1-9021-2b58998986cd">
